### PR TITLE
Fix `mismatched sequence in netlink reply`

### DIFF
--- a/nbdnl/nbd.go
+++ b/nbdnl/nbd.go
@@ -203,7 +203,7 @@ func Connect(idx uint32, socks []*os.File, size uint64, cf ClientFlags, sf Serve
 		},
 		Data: body,
 	}
-	msgs, err := conn.c.Execute(msg, conn.family, netlink.Request|netlink.Acknowledge)
+	msgs, err := conn.c.Execute(msg, conn.family, netlink.Request)
 	if err != nil {
 		return 0, err
 	}
@@ -264,6 +264,8 @@ func Reconfigure(idx uint32, socks []*os.File, cf ClientFlags, sf ServerFlags, o
 		},
 		Data: body,
 	}
+	// Note: nbd_genl_reconfigure doesn't send a reply, so we need to set the
+	// ACK flag here to request a reply from the transport.
 	_, err = conn.c.Execute(msg, conn.family, netlink.Request|netlink.Acknowledge)
 	return err
 }
@@ -287,6 +289,8 @@ func Disconnect(idx uint32) error {
 		},
 		Data: body,
 	}
+	// Note: nbd_genl_disconnect doesn't send a reply, so we need to set the ACK
+	// flag here to request a reply from the transport.
 	_, err = conn.c.Execute(msg, conn.family, netlink.Request|netlink.Acknowledge)
 	return err
 }
@@ -352,7 +356,7 @@ func status(idx uint32) ([]DeviceStatus, error) {
 		},
 		Data: body,
 	}
-	msgs, err := conn.c.Execute(msg, conn.family, netlink.Request|netlink.Acknowledge)
+	msgs, err := conn.c.Execute(msg, conn.family, netlink.Request)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove the `Acknowledge` flag from a few `Execute()` calls. That flag only needs to be set in cases where the driver doesn't already send a reply.

More details here: https://github.com/mdlayher/netlink/issues/108#issuecomment-1575687362

Also relevant: https://github.com/mdlayher/netlink/issues/167

Fixes https://github.com/Merovius/nbd/issues/18